### PR TITLE
fix: set initial value for reducer function

### DIFF
--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -15,7 +15,7 @@ describe('Testing mock data provider and useQuery hook', () => {
             ({ loading, error, data }: QueryRenderInput) => {
                 if (loading) return 'loading'
                 if (error) return <div>error: {error.message}</div>
-                return <div>data: {data}</div>
+                return <div>data: {data.answer}</div>
             }
         )
 
@@ -36,7 +36,7 @@ describe('Testing mock data provider and useQuery hook', () => {
         expect(renderFunction).toHaveBeenCalledTimes(2)
         expect(renderFunction).toHaveBeenLastCalledWith({
             loading: false,
-            data: mockData.answer,
+            data: mockData,
         })
         expect(getByText(/data: /i)).toHaveTextContent(
             `data: ${mockData.answer}`

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -20,7 +20,7 @@ export const useQuery = (query: QueryMap): QueryState => {
             )
             .then(data => setState({ loading: false, data }))
             .catch(error => setState({ loading: false, error }))
-    })
+    }, [])
 
     return state
 }

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -16,11 +16,11 @@ export const useQuery = (query: QueryMap): QueryState => {
                 responses.reduce((out, response, idx) => ({
                     ...out,
                     [names[idx]]: response,
-                }))
+                }), [])
             )
             .then(data => setState({ loading: false, data }))
             .catch(error => setState({ loading: false, error }))
-    }, [])
+    })
 
     return state
 }

--- a/src/types/Query.d.ts
+++ b/src/types/Query.d.ts
@@ -26,11 +26,27 @@ export type QueryMap = {
     [key: string]: QueryDefinition
 }
 
-export interface QueryState {
+export type QueryState = {
     loading: boolean
     error?: FetchError
-    data?: Object
+    data?: any
 }
+
+/*
+// TODO: Use Union type for better static typeguards in consumer
+export interface QueryStateLoading {
+    loading: true
+}
+export interface QueryStateError {
+    loading: false
+    error: FetchError
+}
+export interface QueryStateData {
+    loading: false
+    data: any
+}
+export type QueryState = QueryStateLoading | QueryStateError | QueryStateData
+*/
 
 export type QueryRenderInput = QueryState
 


### PR DESCRIPTION
The initial value (`[]`) looks like it is placed in the wrong context, so instead of being passed to the `reduce` function as the initial value, it is passed to the `useEffect` function as the second parameter. This caused the returned `data` to be the first `response` from the `Promise.all` chain with all the other responses reduced into it.