### PR TITLE
fix(offline): remove offlineInterface.init() functionality

### DIFF
--- a/services/offline/src/lib/__tests__/offline-provider.test.tsx
+++ b/services/offline/src/lib/__tests__/offline-provider.test.tsx
@@ -34,17 +34,6 @@ describe('Testing offline provider', () => {
         expect(screen.getByTestId('test-div')).toBeInTheDocument()
     })
 
-    it('Should initialize the offline interface with an update prompt', () => {
-        render(<OfflineProvider offlineInterface={mockOfflineInterface} />)
-
-        expect(mockOfflineInterface.init).toHaveBeenCalledTimes(1)
-
-        // Expect to have been called with a 'promptUpdate' function
-        const arg = mockOfflineInterface.init.mock.calls[0][0]
-        expect(arg).toHaveProperty('promptUpdate')
-        expect(typeof arg['promptUpdate']).toBe('function')
-    })
-
     it('Should sync cached sections with indexedDB', async () => {
         const testOfflineInterface = {
             ...mockOfflineInterface,
@@ -121,8 +110,6 @@ describe('Testing offline provider', () => {
             </OfflineProvider>
         )
 
-        // Init should still be called - see comments in offline-provider.js
-        expect(testOfflineInterface.init).toHaveBeenCalled()
         expect(screen.getByTestId('test-div')).toBeInTheDocument()
     })
 })

--- a/services/offline/src/lib/offline-interface.tsx
+++ b/services/offline/src/lib/offline-interface.tsx
@@ -1,4 +1,3 @@
-import { useAlert } from '@dhis2/app-service-alerts'
 import PropTypes from 'prop-types'
 import React, { createContext, useContext } from 'react'
 import { OfflineInterface } from '../types'
@@ -6,7 +5,6 @@ import { OfflineInterface } from '../types'
 // This is to prevent 'offlineInterface could be null' type-checking errors
 const noopOfflineInterface: OfflineInterface = {
     pwaEnabled: false,
-    init: () => () => null,
     startRecording: async () => undefined,
     getCachedSections: async () => [],
     removeSection: async () => false,
@@ -21,16 +19,6 @@ interface OfflineInterfaceProviderInput {
     children: React.ReactNode
 }
 
-interface AlertAction {
-    label: string
-    onClick: () => void
-}
-
-interface PromptUpdateAlertOptions {
-    message: string
-    actions: AlertAction[]
-}
-
 /**
  * Receives an OfflineInterface instance as a prop (presumably from the app
  * adapter) and provides it as context for other offline tools.
@@ -43,19 +31,6 @@ export function OfflineInterfaceProvider({
     offlineInterface,
     children,
 }: OfflineInterfaceProviderInput): JSX.Element {
-    const { show } = useAlert(
-        ({ message }: PromptUpdateAlertOptions) => message,
-        ({ actions }: PromptUpdateAlertOptions) => ({
-            actions,
-            permanent: true,
-        })
-    )
-
-    React.useEffect(() => {
-        // Init returns a tear-down function
-        return offlineInterface.init({ promptUpdate: show })
-    }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
     return (
         <OfflineInterfaceContext.Provider value={offlineInterface}>
             {children}

--- a/services/offline/src/lib/offline-provider.tsx
+++ b/services/offline/src/lib/offline-provider.tsx
@@ -20,15 +20,6 @@ export function OfflineProvider({
         return <>{children}</>
     }
 
-    // If PWA is not enabled, just init interface to make sure new SW gets
-    // activated with code that unregisters SW. Not technically necessary if a
-    // killswitch SW takes over, but the killswitch may not always be in use.
-    // Then, skip adding any context
-    if (!offlineInterface.pwaEnabled) {
-        offlineInterface.init({ promptUpdate: ({ onConfirm }) => onConfirm() })
-        return <>{children}</>
-    }
-
     return (
         <OfflineInterfaceProvider offlineInterface={offlineInterface}>
             <CacheableSectionProvider>{children}</CacheableSectionProvider>
@@ -39,7 +30,6 @@ export function OfflineProvider({
 OfflineProvider.propTypes = {
     children: PropTypes.node,
     offlineInterface: PropTypes.shape({
-        init: PropTypes.func,
         pwaEnabled: PropTypes.bool,
     }),
 }

--- a/services/offline/src/types.ts
+++ b/services/offline/src/types.ts
@@ -35,10 +35,6 @@ export interface GlobalStateStore {
 
 // Offline Interface types
 
-interface PromptUpdate {
-    (params: { message: string; action: string; onConfirm: () => void }): void
-}
-
 interface StartRecording {
     (params: {
         sectionId: string
@@ -58,7 +54,6 @@ export interface IndexedDBCachedSection {
 
 export interface OfflineInterface {
     readonly pwaEnabled: boolean
-    init: (params: { promptUpdate: PromptUpdate }) => () => void
     startRecording: StartRecording
     getCachedSections: () => Promise<IndexedDBCachedSection[]>
     removeSection: (id: string) => Promise<boolean>

--- a/services/offline/src/utils/test-mocks.ts
+++ b/services/offline/src/utils/test-mocks.ts
@@ -30,7 +30,6 @@ export const failedMessageRecordingMock = jest
 
 export const mockOfflineInterface = {
     pwaEnabled: true,
-    init: jest.fn(),
     startRecording: successfulRecordingMock,
     getCachedSections: jest.fn().mockResolvedValue([]),
     removeSection: jest.fn().mockResolvedValue(true),


### PR DESCRIPTION
Back-port of https://github.com/dhis2/app-runtime/pull/1041

Part of https://jira.dhis2.org/browse/LIBS-237

The app runtime will no longer need to use any `init()` or update functionality for PWA; that will be handled in the App Adapter by https://github.com/dhis2/app-platform/pull/672 (once it's back-ported to `7.x`)