### PR TITLE
fix(offline-provider): avoid side-effects if PWA is disabled

### DIFF
--- a/services/offline/src/lib/offline-provider.tsx
+++ b/services/offline/src/lib/offline-provider.tsx
@@ -16,7 +16,7 @@ export function OfflineProvider({
 }: OfflineProviderInput): JSX.Element {
     // If an offline interface is not provided, or if one is provided and PWA
     // is not enabled, skip adding context providers
-    if (!offlineInterface) {
+    if (!offlineInterface || !offlineInterface.pwaEnabled) {
         return <>{children}</>
     }
 


### PR DESCRIPTION
The previous SW update PR introduced a regression where PWA context providers were being added to non-pwa apps, throwing an error 'Cannot get cached sections - PWA is not enabled in d2.config.js' -- this reintroduces the check that was removed