### PR TITLE
fix: expose QueryOptions and MutationOptions type

### DIFF
--- a/services/data/src/types.ts
+++ b/services/data/src/types.ts
@@ -2,9 +2,10 @@ import DataEngine from './engine/DataEngine'
 import { QueryExecuteOptions } from './engine/types/ExecuteOptions'
 import { FetchError } from './engine/types/FetchError'
 import { JsonValue } from './engine/types/JsonValue'
-import { Mutation } from './engine/types/Mutation'
-import { QueryVariables, QueryResult, Query } from './engine/types/Query'
+import { QueryVariables, QueryResult } from './engine/types/Query'
 
+export type { Mutation } from './engine/types/Mutation'
+export type { Query } from './engine/types/Query'
 export interface ContextType {
     engine: DataEngine
 }
@@ -14,8 +15,6 @@ export interface ContextInput {
     apiVersion: number
 }
 
-export type QueryOptions = Query
-export type MutationOptions = Mutation
 export type ExecuteOptions = QueryExecuteOptions
 export type RefetchOptions = QueryVariables
 export type RefetchFunction<ReturnType> = (


### PR DESCRIPTION
This PR exposes the `Query` and `Mutation` type as `QueryOptions` and `MutationOptions`. Use case for this is that I am trying to hook the `DataEngine` up with the RTK Query / Redux Toolkit. I am adding an instance of the `DataEngine` using `createDynamicMiddleWare`. This allows me to then access the the data engine in my `customBaseQuery`. However, I need to accurately type the arguments which may be passed to this base query and these arguments should match whatever I can pass to `engine.query` or `engine.mutate`. Hence this PR.

In my second commit [49b7155](https://github.com/dhis2/app-runtime/pull/1414/commits/49b71552f169ba1f82e251933d3751fe48eab6b9) I export `QueryExecuteOptions` as `ExecuteOptions`. I'm a bit unsure about this because it makes the name more generic, which probably isn't a good thing... The thinking behind it is as follows:
- `engine.query` and `engine.mutate` take two positional arguments and the second one for each is of type `QueryExecuteOptions`
- I thought having a prefix with `Query` for the second positional argument which is also used by `engine.mutate` is a bit confusing