### PR TITLE
chore: update types to avoid implicit any

### DIFF
--- a/services/alerts/src/AlertsProvider.tsx
+++ b/services/alerts/src/AlertsProvider.tsx
@@ -5,14 +5,14 @@ import { makeAlertsManager } from './makeAlertsManager'
 import type { Alert, AlertsManager } from './types'
 
 export const AlertsProvider = ({
-    plugin,
+    plugin = false,
     parentAlertsAdd,
-    showAlertsInPlugin,
+    showAlertsInPlugin = false,
     children,
 }: {
-    plugin: boolean
-    parentAlertsAdd: any
-    showAlertsInPlugin: boolean
+    plugin?: boolean
+    parentAlertsAdd?: any
+    showAlertsInPlugin?: boolean
     children: React.ReactNode
 }): ReactElement => {
     const [alerts, setAlerts] = useState<Alert[]>([])

--- a/services/alerts/src/__tests__/integration.test.tsx
+++ b/services/alerts/src/__tests__/integration.test.tsx
@@ -137,7 +137,7 @@ describe('useAlert and useAlerts used together', () => {
         })
 
         act(() => {
-            result.current.alerts[0].remove()
+            result.current.alerts[0].remove!()
         })
 
         expect(result.current.alerts).toHaveLength(0)
@@ -374,7 +374,7 @@ describe('useAlert and useAlerts used together', () => {
         expect(result.current.alerts[1].id).toBe(2)
 
         act(() => {
-            result.current.alerts[0].remove()
+            result.current.alerts[0].remove!()
         })
 
         expect(result.current.alerts).toHaveLength(1)

--- a/services/config/src/__tests__/integration.test.tsx
+++ b/services/config/src/__tests__/integration.test.tsx
@@ -8,6 +8,7 @@ const mockConfig: Config = {
     baseUrl: 'http://test.com',
     apiVersion: 42,
     serverVersion: {
+        full: '2.35-SNAPSHOT',
         major: 2,
         minor: 35,
         patch: undefined,
@@ -16,6 +17,7 @@ const mockConfig: Config = {
     systemInfo: {
         contextPath: 'http://localhost:3000',
         version: '2.35-SNAPSHOT',
+        serverTimeZoneId: 'UTC',
     },
 }
 

--- a/services/data/src/__tests__/integration.test.tsx
+++ b/services/data/src/__tests__/integration.test.tsx
@@ -7,7 +7,7 @@ describe('<DataQuery />', () => {
         const data = {
             answer: 42,
         }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
         const renderFunction = jest.fn(() => null)
@@ -46,7 +46,7 @@ describe('<DataQuery />', () => {
                 throw expectedError
             },
         }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
         const renderFunction = jest.fn(() => null)

--- a/services/data/src/__tests__/mutations.test.tsx
+++ b/services/data/src/__tests__/mutations.test.tsx
@@ -7,7 +7,7 @@ describe('<DataMutation />', () => {
         const endpointSpy = jest.fn(() => Promise.resolve(42))
         const mutation = {
             resource: 'answer',
-            type: 'create',
+            type: 'create' as const,
             data: {
                 question: '?',
             },
@@ -15,10 +15,10 @@ describe('<DataMutation />', () => {
         const data = {
             answer: endpointSpy,
         }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
-        const renderSpy = jest.fn(() => null)
+        const renderSpy: jest.Mock = jest.fn(() => null)
         render(<DataMutation mutation={mutation}>{renderSpy}</DataMutation>, {
             wrapper,
         })

--- a/services/data/src/react/hooks/mergeAndCompareVariables.test.ts
+++ b/services/data/src/react/hooks/mergeAndCompareVariables.test.ts
@@ -1,7 +1,7 @@
 import { mergeAndCompareVariables } from './mergeAndCompareVariables'
 import { stableVariablesHash } from './stableVariablesHash'
 jest.mock('./stableVariablesHash', () => ({
-    stableVariablesHash: (object) => JSON.stringify(object),
+    stableVariablesHash: (object: unknown) => JSON.stringify(object),
 }))
 
 const testVariables = {

--- a/services/data/src/react/hooks/stableVariablesHash.ts
+++ b/services/data/src/react/hooks/stableVariablesHash.ts
@@ -40,10 +40,10 @@ export function stableVariablesHash(value: any): string {
             isPlainObject(val)
                 ? Object.keys(val)
                       .sort()
-                      .reduce((result, key) => {
-                          result[key] = val[key]
+                      .reduce((result: Record<string, unknown>, key) => {
+                          result[key] = (val as Record<string, unknown>)[key]
                           return result
-                      }, {} as any)
+                      }, {})
                 : val
         )
     } catch (e) {

--- a/services/data/src/react/hooks/useDataMutation.test.tsx
+++ b/services/data/src/react/hooks/useDataMutation.test.tsx
@@ -1,4 +1,8 @@
-import type { CreateMutation, UpdateMutation } from '@dhis2/data-engine'
+import type {
+    CreateMutation,
+    UpdateMutation,
+    QueryVariables,
+} from '@dhis2/data-engine'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { CustomDataProvider } from '../components/CustomDataProvider'
@@ -13,7 +17,7 @@ describe('useDataMutation', () => {
             data: { answer: '?' },
         }
         const data = { answer: 42 }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -56,7 +60,7 @@ describe('useDataMutation', () => {
             data: { answer: '?' },
         }
         const data = { answer: 42 }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -89,7 +93,7 @@ describe('useDataMutation', () => {
             data: { answer: '?' },
         }
         const data = { answer: 42 }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -129,7 +133,7 @@ describe('useDataMutation', () => {
                 throw error
             },
         }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -158,15 +162,15 @@ describe('useDataMutation', () => {
     })
 
     it('should resolve variables', async () => {
-        const mutation: UpdateMutation = {
+        const mutation = {
             type: 'update',
             resource: 'answer',
-            id: ({ id }) => id,
+            id: ({ id }: QueryVariables) => id as string,
             data: { answer: '?' },
-        }
+        } as unknown as UpdateMutation
         const answerSpy = jest.fn(() => Promise.resolve(42))
         const data = { answer: answerSpy }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -211,7 +215,7 @@ describe('useDataMutation', () => {
             resource: 'answer',
             data: { answer: '?' },
         }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={{}}>{children}</CustomDataProvider>
         )
 
@@ -236,7 +240,7 @@ describe('useDataMutation', () => {
             data: { answer: '?' },
         }
         const data = { answer: 42 }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -265,7 +269,7 @@ describe('useDataMutation', () => {
             data: { answer: '?' },
         }
         const data = { answer: 42 }
-        const wrapper = ({ children }) => (
+        const wrapper = ({ children }: { children?: React.ReactNode }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
 
@@ -273,7 +277,7 @@ describe('useDataMutation', () => {
             wrapper,
         })
 
-        let mutatePromise
+        let mutatePromise!: Promise<unknown>
         const [mutate] = result.current
         act(() => {
             mutatePromise = mutate()

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -1,3 +1,4 @@
+import type { QueryVariables } from '@dhis2/data-engine'
 import { renderHook, waitFor, act } from '@testing-library/react'
 import * as React from 'react'
 import { CustomDataProvider } from '../components/CustomDataProvider'
@@ -8,7 +9,7 @@ describe('useDataQuery', () => {
         it('Should call onComplete with the data after a successful fetch', async () => {
             const query = { x: { resource: 'answer' } }
             const data = { answer: 42 }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
             const onComplete = jest.fn()
@@ -43,7 +44,7 @@ describe('useDataQuery', () => {
                     throw expectedError
                 },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
             const onComplete = jest.fn()
@@ -76,7 +77,10 @@ describe('useDataQuery', () => {
             const resultOne = 1
             const resultTwo = 2
             const query = {
-                x: { resource: 'answer', id: ({ id }) => id },
+                x: {
+                    resource: 'answer',
+                    id: ({ id }: QueryVariables) => id as string,
+                },
             }
             const mockSpy = jest.fn((_, { id }) => {
                 switch (id) {
@@ -141,7 +145,7 @@ describe('useDataQuery', () => {
             const query = { x: { resource: 'answer' } }
             const mockSpy = jest.fn(() => Promise.resolve(42))
             const data = { answer: mockSpy }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -183,7 +187,7 @@ describe('useDataQuery', () => {
             const query = {
                 x: { resource: 'answer' },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider
                     data={data}
                     queryClientOptions={queryClientOptions}
@@ -253,7 +257,7 @@ describe('useDataQuery', () => {
             const query = {
                 x: { resource: 'answer' },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -293,7 +297,7 @@ describe('useDataQuery', () => {
         it('Should return the data for a single resource query on success', async () => {
             const query = { x: { resource: 'answer' } }
             const data = { answer: 42 }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -321,7 +325,7 @@ describe('useDataQuery', () => {
                 y: { resource: 'opposite' },
             }
             const data = { answer: 42, opposite: 24 }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -353,7 +357,7 @@ describe('useDataQuery', () => {
                     throw expectedError
                 },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -387,7 +391,7 @@ describe('useDataQuery', () => {
                 },
                 opposite: 24,
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -423,7 +427,7 @@ describe('useDataQuery', () => {
             const query = {
                 x: { resource: 'answer' },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -479,9 +483,12 @@ describe('useDataQuery', () => {
                 answer: spy,
             }
             const query = {
-                x: { resource: 'answer', id: ({ id }) => id },
+                x: {
+                    resource: 'answer',
+                    id: ({ id }: QueryVariables) => id as string,
+                },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -521,9 +528,12 @@ describe('useDataQuery', () => {
                 answer: spy,
             }
             const query = {
-                x: { resource: 'answer', id: ({ id }) => id },
+                x: {
+                    resource: 'answer',
+                    id: ({ id }: QueryVariables) => id as string,
+                },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -557,7 +567,7 @@ describe('useDataQuery', () => {
                 answer: () => Promise.resolve(42),
             }
             const query = { x: { resource: 'answer' } }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -592,7 +602,7 @@ describe('useDataQuery', () => {
                 answer: mockSpy,
             }
             const query = { x: { resource: 'answer' } }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -648,7 +658,7 @@ describe('useDataQuery', () => {
             const query = { x: { resource: 'answer' } }
             const mockSpy = jest.fn(() => Promise.resolve(42))
             const data = { answer: mockSpy }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -685,7 +695,7 @@ describe('useDataQuery', () => {
         it('Should call onComplete after a successful refetch', async () => {
             const query = { x: { resource: 'answer' } }
             const data = { answer: 42 }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
             const onComplete = jest.fn()
@@ -719,7 +729,7 @@ describe('useDataQuery', () => {
                     throw expectedError
                 },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
             const onComplete = jest.fn()
@@ -748,12 +758,16 @@ describe('useDataQuery', () => {
             const query = {
                 x: {
                     resource: 'answer',
-                    params: ({ one, two, three }) => ({ one, two, three }),
+                    params: ({ one, two, three }: QueryVariables) => ({
+                        one,
+                        two,
+                        three,
+                    }),
                 },
             }
             const spy = jest.fn(() => Promise.resolve(42))
             const data = { answer: spy }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -788,7 +802,7 @@ describe('useDataQuery', () => {
         it('Should return a promise that resolves with the data on success when refetching and lazy', async () => {
             const query = { x: { resource: 'answer' } }
             const data = { answer: 42 }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -797,7 +811,7 @@ describe('useDataQuery', () => {
                 { wrapper }
             )
 
-            let ourPromise
+            let ourPromise!: Promise<unknown>
             act(() => {
                 // This refetch will trigger our own refetch logic as the query is lazy
                 ourPromise = result.current.refetch()
@@ -816,7 +830,7 @@ describe('useDataQuery', () => {
         it('Should return a promise that resolves with the data on success when refetching and not lazy', async () => {
             const query = { x: { resource: 'answer' } }
             const data = { answer: 42 }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -825,7 +839,7 @@ describe('useDataQuery', () => {
                 { wrapper }
             )
 
-            let reactQueryPromise
+            let reactQueryPromise!: Promise<unknown>
             act(() => {
                 // This refetch will trigger react query's refetch logic as the query is not lazy
                 reactQueryPromise = result.current.refetch()
@@ -849,7 +863,7 @@ describe('useDataQuery', () => {
                     throw expectedError
                 },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -858,7 +872,7 @@ describe('useDataQuery', () => {
                 { wrapper }
             )
 
-            let ourPromise
+            let ourPromise!: Promise<unknown>
             act(() => {
                 // This refetch will trigger our own refetch logic as the query is lazy
                 ourPromise = result.current.refetch()
@@ -880,7 +894,7 @@ describe('useDataQuery', () => {
                     throw expectedError
                 },
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 
@@ -889,7 +903,7 @@ describe('useDataQuery', () => {
                 { wrapper }
             )
 
-            let reactQueryPromise
+            let reactQueryPromise!: Promise<unknown>
             act(() => {
                 // This refetch will trigger react query's refetch logic as the query is not lazy
                 reactQueryPromise = result.current.refetch()
@@ -909,7 +923,10 @@ describe('useDataQuery', () => {
             const resultOne = 1
             const resultTwo = 2
             const query = {
-                x: { resource: 'answer', id: ({ id }) => id },
+                x: {
+                    resource: 'answer',
+                    id: ({ id }: QueryVariables) => id as string,
+                },
             }
             const mockSpy = jest.fn((_, { id }) => {
                 switch (id) {
@@ -963,14 +980,18 @@ describe('useDataQuery', () => {
             const query = {
                 x: {
                     resource: 'answer',
-                    params: ({ one, two, three }) => ({ one, two, three }),
+                    params: ({ one, two, three }: QueryVariables) => ({
+                        one,
+                        two,
+                        three,
+                    }),
                 },
             }
             const mockSpy = jest.fn(() => Promise.resolve(42))
             const data = {
                 answer: mockSpy,
             }
-            const wrapper = ({ children }) => (
+            const wrapper = ({ children }: { children?: React.ReactNode }) => (
                 <CustomDataProvider data={data}>{children}</CustomDataProvider>
             )
 

--- a/services/offline/src/declarations.d.ts
+++ b/services/offline/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module 'fake-indexeddb/lib/FDBFactory'

--- a/services/offline/src/lib/__tests__/use-online-status-message.test.tsx
+++ b/services/offline/src/lib/__tests__/use-online-status-message.test.tsx
@@ -1,12 +1,12 @@
 import { renderHook, act } from '@testing-library/react'
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import { mockOfflineInterface } from '../../utils/test-mocks'
 import { OfflineProvider } from '../offline-provider'
 import { useOnlineStatusMessage } from '../online-status-message'
 
 describe('useOnlineStatusMessage', () => {
     it('should allow the online status to be updated ', () => {
-        const wrapper: FC = ({ children }) => (
+        const wrapper: FC<{ children?: ReactNode }> = ({ children }) => (
             <OfflineProvider offlineInterface={mockOfflineInterface}>
                 {children}
             </OfflineProvider>

--- a/services/offline/src/lib/dhis2-connection-status/dhis2-connection-status.test.tsx
+++ b/services/offline/src/lib/dhis2-connection-status/dhis2-connection-status.test.tsx
@@ -45,7 +45,7 @@ const INTERVALS_TO_REACH_MAX_DELAY = Math.ceil(
         1
 )
 
-const wrapper: React.FC = ({ children }) => (
+const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
     <ConfigProvider
         config={{
             baseUrl: '..',
@@ -118,7 +118,9 @@ describe('initialization to the right values based on offline interface', () => 
             ...mockOfflineInterface,
             latestIsConnected: false,
         }
-        const customWrapper: React.FC = ({ children }) => (
+        const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+            children,
+        }) => (
             <OfflineProvider offlineInterface={customMockOfflineInterface}>
                 {children}
             </OfflineProvider>
@@ -146,7 +148,9 @@ describe('initialization to the right values based on offline interface', () => 
             ...mockOfflineInterface,
             latestIsConnected: null,
         }
-        const customWrapper: React.FC = ({ children }) => (
+        const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+            children,
+        }) => (
             <OfflineProvider offlineInterface={customMockOfflineInterface}>
                 {children}
             </OfflineProvider>
@@ -703,7 +707,9 @@ describe('lastConnected status', () => {
                 ...mockOfflineInterface,
                 latestIsConnected: false,
             }
-            const customWrapper: React.FC = ({ children }) => (
+            const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+                children,
+            }) => (
                 <OfflineProvider offlineInterface={customMockOfflineInterface}>
                     {children}
                 </OfflineProvider>
@@ -733,7 +739,9 @@ describe('lastConnected status', () => {
                 ...mockOfflineInterface,
                 latestIsConnected: false,
             }
-            const customWrapper: React.FC = ({ children }) => (
+            const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+                children,
+            }) => (
                 <OfflineProvider offlineInterface={customMockOfflineInterface}>
                     {children}
                 </OfflineProvider>
@@ -765,7 +773,9 @@ describe('lastConnected status', () => {
             ...mockOfflineInterface,
             latestIsConnected: false,
         }
-        const customWrapper: React.FC = ({ children }) => (
+        const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+            children,
+        }) => (
             <ConfigProvider
                 config={{
                     baseUrl: '..',
@@ -829,7 +839,9 @@ describe('lastConnected status', () => {
             ...mockOfflineInterface,
             latestIsConnected: false,
         }
-        const customWrapper: React.FC = ({ children }) => (
+        const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+            children,
+        }) => (
             <ConfigProvider
                 config={{
                     baseUrl: '..',
@@ -879,7 +891,9 @@ describe('lastConnected status', () => {
 })
 
 describe("when the /api/ping endpoint isn't supported", () => {
-    const customWrapper: React.FC = ({ children }) => (
+    const customWrapper: React.FC<{ children?: React.ReactNode }> = ({
+        children,
+    }) => (
         <ConfigProvider
             config={{
                 baseUrl: '..',

--- a/services/user/src/__tests__/useCurrentUserInfoHook.test.tsx
+++ b/services/user/src/__tests__/useCurrentUserInfoHook.test.tsx
@@ -13,7 +13,7 @@ const mockUser = {
 }
 
 test('When a valid userInfo object is provided', () => {
-    const wrapper = ({ children }) => (
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
         <UserProvider userInfo={mockUser}>{children}</UserProvider>
     )
     const { result } = renderHook(() => useCurrentUserInfo(), { wrapper })
@@ -21,7 +21,7 @@ test('When a valid userInfo object is provided', () => {
 })
 
 test('When the userInfo object provided is undefined', async () => {
-    const wrapper = ({ children }) => (
+    const wrapper = ({ children }: { children?: React.ReactNode }) => (
         <UserProvider userInfo={undefined as any}>{children}</UserProvider>
     )
     const { result } = renderHook(() => useCurrentUserInfo(), { wrapper })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "target": "esnext",
         "declaration": true,
         "module": "esnext",
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         // Search under node_modules for non-relative imports.
         "moduleResolution": "node",
         // Process & infer types from .js files.


### PR DESCRIPTION
we had to allow `implicitAny` in order to merge beta to master as there were many issues there already. This PR fixes the TypeScript issues, so that we can turn `noImplicitAny` to  `true` again.